### PR TITLE
fix: rm npm version from engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `npm` version from `engines` field in package.json. At this moment, there isn't any specific case why a specific subset of `npm` versions is needed
 
 ## [1.2.1] - 2021-02-24
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "main": "dist/rollup-plugin-banner2.cjs.js",
   "module": "dist/rollup-plugin-banner2.es.js",
   "engines": {
-    "node": ">=12.13.0",
-    "npm": "^6.13.4"
+    "node": ">=12.13.0"
   },
   "version": "1.2.1",
   "description": "Rollup plugin to add banner in built files",


### PR DESCRIPTION
Closes https://github.com/stropho/rollup-plugin-banner2/issues/11